### PR TITLE
Refactor DynamoDB test and clients to make it easier to handle local database

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,11 @@ jobs:
       - run:
           name: Configure AWS
           command: |
-            aws configure set aws_access_key_id TestAccessKey --profile testing
-            aws configure set aws_secret_access_key TestSecretKey --profile testing
-            aws configure set region eu-west-2 --profile testing
-            aws configure set cli_pager "" --profile testing
-
-      - run:
-          name: Create Table
-          command: aws dynamodb --profile testing --no-paginate create-table --table-name comino-printing-test-letters-2 --attribute-definitions AttributeName=InitialTimestamp,AttributeType=S --key-schema AttributeName=InitialTimestamp,KeyType=HASH --endpoint-url http://localhost:8000 --billing-mode PAY_PER_REQUEST
-
+            aws configure set aws_access_key_id TestAccessKey
+            aws configure set aws_secret_access_key TestSecretKey
+            aws configure set region eu-west-2
+            aws configure set cli_pager ""
+      
       - run:
           name: Install dependencies
           command: dotnet restore

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ RtfParseTests/BlankBenefitsRtf/
 node_modules
 .serverless
 
+*.testlog
+*.manifest
+*.suo

--- a/src/Gateways/DynamoDBClient.cs
+++ b/src/Gateways/DynamoDBClient.cs
@@ -1,0 +1,14 @@
+﻿using Amazon.DynamoDBv2;
+
+namespace Gateways
+{
+    public class DynamoDBClient
+    {
+        public AmazonDynamoDBClient Client { get; set; }
+
+        public DynamoDBClient(AmazonDynamoDBConfig dynamoConfig)
+        {
+            Client = new AmazonDynamoDBClient(dynamoConfig);
+        }
+    }
+}

--- a/src/Gateways/DynamoDBHandler.cs
+++ b/src/Gateways/DynamoDBHandler.cs
@@ -1,34 +1,23 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
-using Amazon.Runtime;
+using System;
 
 namespace Gateways
 {
     public class DynamoDBHandler : IDynamoDBHandler
     {
-        public DynamoDBHandler(AmazonDynamoDBConfig dynamoConfig, string tableName)
+        private readonly AmazonDynamoDBClient _client;
+
+        public DynamoDBHandler(string tableName, DynamoDBClient dynamoDBClient)
         {
-            // TEMPORARY: debugging AWS SDK DynamoDB tests - hanging due to auth issue?
-            if (Environment.GetEnvironmentVariable("DYNAMODB_SET_DUMMY_AUTH") == "true")
-            {
-                var credentials = new BasicAWSCredentials("TestAccessKey", "TestSecretKey");
-                var client = new AmazonDynamoDBClient(credentials, dynamoConfig);
-                Console.WriteLine($"> setting DocumentTable: {tableName}");
-                DocumentTable = Table.LoadTable(client, tableName);
-                DatabaseClient = client;
-            }
-            else
-            {
-                var client = new AmazonDynamoDBClient(dynamoConfig);
-                DocumentTable = Table.LoadTable(client, tableName);
-                DatabaseClient = client;
-            }
+            _client = dynamoDBClient.Client;
+
+            Console.WriteLine($"> setting DocumentTable: {tableName}");
+            DocumentTable = Table.LoadTable(_client, tableName);
+            DynamoDBClient = _client;
         }
 
-        public AmazonDynamoDBClient DatabaseClient { get; }
+        public AmazonDynamoDBClient DynamoDBClient { get; }
         public Table DocumentTable { get; }
     }
 }

--- a/src/Gateways/IDynamoDBHandler.cs
+++ b/src/Gateways/IDynamoDBHandler.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Amazon.DynamoDBv2;
 using Amazon.DynamoDBv2.DocumentModel;
 
@@ -8,6 +6,6 @@ namespace Gateways
     public interface IDynamoDBHandler
     {
         Table DocumentTable { get; }
-        AmazonDynamoDBClient DatabaseClient { get; }
+        AmazonDynamoDBClient DynamoDBClient { get; }
     }
 }

--- a/src/Gateways/LocalDatabaseGateway.cs
+++ b/src/Gateways/LocalDatabaseGateway.cs
@@ -21,7 +21,7 @@ namespace Gateways
         public LocalDatabaseGateway(IDynamoDBHandler database)
         {
             _documentsTable = database.DocumentTable;
-            _databaseClient = database.DatabaseClient;
+            _databaseClient = database.DynamoDBClient;
         }
 
         public async Task<string> SaveDocument(DocumentDetails newDocument)

--- a/src/Lambda/ConfigureServices.cs
+++ b/src/Lambda/ConfigureServices.cs
@@ -28,7 +28,8 @@ namespace AwsDotnetCsharp
             var tableName = Environment.GetEnvironmentVariable("LETTERS_TABLE_NAME");
             LambdaLogger.Log($"Dynamo table name {tableName}");
             var dynamoConfig = new AmazonDynamoDBConfig {RegionEndpoint = RegionEndpoint.EUWest2};
-            services.AddTransient<IDynamoDBHandler>(sp => new DynamoDBHandler(dynamoConfig, tableName));
+            var dynamoDBClient = new DynamoDBClient(dynamoConfig);
+            services.AddTransient<IDynamoDBHandler>(sp => new DynamoDBHandler(tableName, dynamoDBClient));
 
             //SQS
             services.AddTransient<IAmazonSQS>(sp => new AmazonSQSClient(RegionEndpoint.EUWest2));

--- a/test/GatewayTests/DynamoDbTests.cs
+++ b/test/GatewayTests/DynamoDbTests.cs
@@ -1,46 +1,76 @@
-using System;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
 using Amazon;
 using Amazon.DynamoDBv2;
-using Amazon.DynamoDBv2.DocumentModel;
 using Amazon.DynamoDBv2.Model;
 using Gateways;
-using Newtonsoft.Json;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace GatewayTests
 {
     public class DynamoDbTests
     {
         protected DynamoDBHandler DatabaseClient;
+        protected string tableName = Environment.GetEnvironmentVariable("LETTERS_TABLE_NAME") ?? "comino-printing-test-letters-2";
 
         [SetUp]
         public void DynamoDbSetUp()
         {
-            Environment.SetEnvironmentVariable("DYNAMODB_SET_DUMMY_AUTH", "true");
-
             var config = new AmazonDynamoDBConfig
             {
                 RegionEndpoint = RegionEndpoint.EUWest2,
-                ServiceURL = "http://localhost:8000",
+                ServiceURL = "http://localhost:8000", //tell SDK to use local database
             };
 
-            var tableName = Environment.GetEnvironmentVariable("LETTERS_TABLE_NAME") ?? "comino-printing-test-letters-2";
-            DatabaseClient = new DynamoDBHandler(config, tableName);
+            DynamoDBClient dynamoDBClient = new DynamoDBClient(config);
+
+            var request = new ListTablesRequest();
+            var listTablesResponse = dynamoDBClient.Client.ListTablesAsync(request).Result;
+
+            if (!listTablesResponse.TableNames.Contains(tableName))
+            {
+                var createTableRequest = new CreateTableRequest
+                {
+                    AttributeDefinitions = new List<AttributeDefinition>()
+                        {
+                            new AttributeDefinition
+                            {
+                                AttributeName = "InitialTimestamp",
+                                AttributeType = "S"
+                            }
+                        },
+                    KeySchema = new List<KeySchemaElement>
+                        {
+                            new KeySchemaElement
+                            {
+                                AttributeName = "InitialTimestamp",
+                                KeyType = "HASH"
+                            }
+                        },
+                    ProvisionedThroughput = new ProvisionedThroughput
+                    {
+                        ReadCapacityUnits = 20,
+                        WriteCapacityUnits = 10
+                    },
+                    TableName = tableName
+                };
+                var response = dynamoDBClient.Client.CreateTableAsync(createTableRequest).Result;
+            }
+
+            DatabaseClient = new DynamoDBHandler(tableName, dynamoDBClient);
         }
 
         [TearDown]
         public async Task DynamoDbTearDown()
         {
-            var scanFilter = new ScanFilter();
+            //delete the table created above
+            var request = new ListTablesRequest();
+            var listTablesResponse = DatabaseClient.DynamoDBClient.ListTablesAsync(request).Result;
 
-            var search = DatabaseClient.DocumentTable.Scan(scanFilter);
-            var items = await search.GetRemainingAsync();
-            foreach (var document in items)
+            if (listTablesResponse.TableNames.Contains(tableName))
             {
-                await DatabaseClient.DocumentTable.DeleteItemAsync(document);
+                await DatabaseClient.DynamoDBClient.DeleteTableAsync(tableName);
             }
         }
     }

--- a/test/GatewayTests/LocalDatabaseGatewayTests.cs
+++ b/test/GatewayTests/LocalDatabaseGatewayTests.cs
@@ -13,7 +13,6 @@ using Usecases.Enums;
 
 namespace GatewayTests
 {
-    [Ignore("to fix")]
     public class LocalDatabaseGatewayTests : DynamoDbTests
     {
         private Fixture _fixture;
@@ -304,7 +303,7 @@ namespace GatewayTests
                 ExpressionAttributeNames = new Dictionary<string, string> {{"#atr", "Log"}},
                 ExpressionAttributeValues = new Dictionary<string, AttributeValue> {{":val", logEntries}}
             };
-            await DatabaseClient.DatabaseClient.UpdateItemAsync(update);
+            await DatabaseClient.DynamoDBClient.UpdateItemAsync(update);
         }
 
         private static Document GetLog(List<Document> savedItems, string savedAt)


### PR DESCRIPTION
1. Add new DynamoDBClient class that handles setting up the AmazonDynamoDBClient. This enables tests to add additional config such as tell SDK to use local database
2. Simplify DynamoDBHandler now that setting up DYNAMODB_SET_DUMMY_AUTH env var is not necessary
3. Rename AmazonDynamoDBClient property in IDynamoDBHandler to make it clear what database type it's for
4. Update service configuration so that instance of DynamoDBClient is passed to the DynamoDBHandler
5. Update DynamoDbTests class so it now creates and tears down the table used in tests
6. Enable all LocalDatabaseGatewayTests
7. Update .gitignore file to remove temp files created by visual studio (*.testlog *.manifest *.suo)

Ensure local AWS credentials (\.aws\credentials) have been set using default profile so SDK won't try to fetch them from AWS.
