### PR TITLE
improve parsers and add support for approval handling

### DIFF
--- a/src/Gateways/CominoGateway.cs
+++ b/src/Gateways/CominoGateway.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using Dapper;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using Dapper;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using Usecases;
 using Usecases.Domain;
 using UseCases.GatewayInterfaces;
 
@@ -21,7 +20,7 @@ namespace Gateways
 
         public List<DocumentDetails> GetDocumentsAfterStartDate(DateTime time)
         {
-            var documentConfig = GetDocumentConfig();
+            var documentConfig = ParsingHelpers.GetDocumentConfig();
             var categories = documentConfig.Categories;
             var descriptions = documentConfig.Descriptions;
             var startTime = $"{time.Month}/{time.Day}/{time.Year} {time.Hour}:{time.Minute}:{time.Second}";
@@ -105,19 +104,6 @@ WHERE CCDocument.DocNo = '{cominoDocumentNumber}';
             public string LetterType { get; set; }
             public string DocumentType { get; set; }
             public DateTime Date { get; set; }
-        }
-
-        public class DocumentConfig
-        {
-            public List<string> Categories { get; set; }
-            public List<string> Descriptions { get; set; }
-        }
-
-        public DocumentConfig GetDocumentConfig()
-        {
-            return JsonConvert.DeserializeObject<DocumentConfig>(
-                Environment.GetEnvironmentVariable("DOCUMENT_CONFIG")
-            );
         }
 
         public class PrintStatusRow

--- a/src/Usecases/DocumentConfig.cs
+++ b/src/Usecases/DocumentConfig.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Usecases
+{
+    public class DocumentConfig
+    {
+        public List<string> Categories { get; set; }
+        public List<string> Descriptions { get; set; }
+        public List<string> AutomaticApprovals { get; set; }
+    }
+}

--- a/src/Usecases/ParsingHelpers.cs
+++ b/src/Usecases/ParsingHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Amazon.Lambda.Core;
@@ -51,6 +52,14 @@ namespace Usecases
         private static List<string> StripEmptyLines(List<string> addressLines)
         {
             return addressLines.Select(line => line.Trim()).Where(line => line != "").ToList();
+        }
+
+        //TODO: handle configuration in its own class/service
+        public static DocumentConfig GetDocumentConfig()
+        {
+            return JsonConvert.DeserializeObject<DocumentConfig>(
+                Environment.GetEnvironmentVariable("DOCUMENT_CONFIG")
+            );
         }
     }
 }

--- a/src/Usecases/UntestedParsers/ChangesInCircsICL.cs
+++ b/src/Usecases/UntestedParsers/ChangesInCircsICL.cs
@@ -20,20 +20,68 @@ namespace Usecases.UntestedParsers
 
             var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
 
+            //add custom styles for print
+            //1. fix checkbox sizes on the last page and ensure the lines are of equal height
+            //2. reduce the height of signature table
+            //3. make sure that content that has to fit on one page is laid out properly and don't overflow to next page 
+            templateSpecificCss = templateSpecificCss.Replace("-->",
+              @"#parser-signature-table tr td
+                {height:10mm !important; padding-left: 5mm !important;}
+                
+                #parser-declaration-table td {height: 5mm !important;}
+
+                #parser-declaration-table tr:nth-child(1) td:first-child,
+                #parser-declaration-table tr:nth-child(5) td:first-child, 
+                #parser-declaration-table tr:nth-child(9) td:first-child,
+                #parser-declaration-table tr:nth-child(13) td:first-child
+                {width:5mm !important;padding-left:2mm !important;}
+              
+                #parser-declaration-table tr:nth-child(1) td:last-child,
+                #parser-declaration-table tr:nth-child(5) td:last-child,
+                #parser-declaration-table tr:nth-child(9) td:last-child,
+                #parser-declaration-table tr:nth-child(13) td:last-child
+                {padding-left:5mm !important;}
+              
+                #parser-declaration-table tr:nth-child(2) td:first-child,
+                #parser-declaration-table tr:nth-child(6) td:first-child,
+                #parser-declaration-table tr:nth-child(10) td:first-child,
+                #parser-declaration-table tr:nth-child(14) td:first-child
+                {width:5mm !important;}
+
+                #parser-declaration-table tr:last-child td{height:auto !important;}
+              
+                #parser-claim-reference-table {page-break-before: always;}
+                #parser-claim-reference-table td:last-child {width: 85mm !important; word-break:break-all;};
+
+              -->");
+
             return new LetterTemplate
             {
                 TemplateSpecificCss = templateSpecificCss,
                 AddressLines = address,
                 RightSideOfHeader = rightSideOfHeader,
-                MainBody = AddLineBreaks(mainBody).OuterHtml,
+                MainBody = AddPageBreaks(mainBody).OuterHtml,
             };
         }
 
-        private static HtmlNode AddLineBreaks(HtmlNode body)
+        private static HtmlNode AddPageBreaks(HtmlNode body)
         {
-            var startOfPage2 = body.ChildNodes.ToList()
-                .Find(node => node.InnerText == "Revenues &amp; Benefits Service");
-            startOfPage2.Attributes.Add("style", "page-break-before: always;");
+            //page break for information page
+            var informationPage = body.ChildNodes.ToList().Find(node => node.InnerText.Contains("Revenues &amp; Benefits Service"));
+            informationPage.Attributes.Add("style", "page-break-before: always;");
+
+            //get the claim reference table and add custom id
+            var claimRefenceTable = body.SelectSingleNode("table[2]");
+            claimRefenceTable.Attributes.Add("id", "parser-claim-reference-table");
+
+            //get the signature table and add custom id
+            var signatureTable = body.SelectSingleNode("table[3]");
+            signatureTable.Attributes.Add("id", "parser-signature-table");
+
+            //get the declaration table and add custom id
+            var lastTable = body.SelectNodes("table").Last();
+            lastTable.Attributes.Add("id", "parser-declaration-table");
+
             return body;
         }
 
@@ -42,7 +90,7 @@ namespace Usecases.UntestedParsers
             var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
             return table
                 .GetRange(1, 7)
-                .Aggregate("", (accString, node) => 
+                .Aggregate("", (accString, node) =>
                     accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
         }
 
@@ -61,10 +109,10 @@ namespace Usecases.UntestedParsers
             var name = documentNode.SelectSingleNode("/html/body/table[1]/tr[8]/td[1]");
             addressList.Add(name.InnerText);
 
-             documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
-                       .ForEach(line => addressList.Add(line.InnerText));
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                      .ForEach(line => addressList.Add(line.InnerText));
 
-             return addressList;
+            return addressList;
         }
 
         private static HtmlNode GetDocumentNode(string html)

--- a/test/GatewayTests/CominoGatewayTests.cs
+++ b/test/GatewayTests/CominoGatewayTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Data;
-using System.Linq;
 using AutoFixture;
 using Dapper;
 using FluentAssertions;
@@ -10,6 +6,11 @@ using Moq;
 using Moq.Dapper;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using UnitTests;
 using Usecases.Domain;
 
 namespace GatewayTests
@@ -27,21 +28,8 @@ namespace GatewayTests
             _subject = new CominoGateway(_connection.Object);
             _fixture = new Fixture();
 
-            Environment.SetEnvironmentVariable("DOCUMENT_CONFIG", DocConfig());
-        }
-
-        [Test]
-        public void GetsDocumentCategoriesFromEnvironmentVariable()
-        {
-            var expected = new {
-                Categories = new List<string>{ "Benefits/Out-Going" },
-                Descriptions = new List<string>{ "Income Verification Document" }
-            };
-
-            var received = _subject.GetDocumentConfig();
-
-            received.Should().BeEquivalentTo(expected);
-        }
+            ConfigurationHelper.SetDocumentConfigEnvironmentVariable();
+        }            
 
         [Test]
         public void GetDocumentsAfterStartDateSendsCorrectQueryToRepository()
@@ -201,16 +189,6 @@ WHERE CCDocument.DocNo = '{cominoDocumentNumber}';
                 Date = doc.Date.ToString("O"),
                 Id = doc.Date.ToString("O"),
             });
-        }
-
-        private string DocConfig()
-        {
-            var configObj = new {
-                Categories = new List<string>{"Benefits/Out-Going"},
-                Descriptions = new List<string>{"Income Verification Document"}
-            };
-
-            return JsonConvert.SerializeObject(configObj);
         }
     }
 }

--- a/test/GatewayTests/GatewayTests.csproj
+++ b/test/GatewayTests/GatewayTests.csproj
@@ -19,6 +19,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Gateways\Gateways.csproj" />
+      <ProjectReference Include="..\UsecaseTests\UsecaseTests.csproj" />
     </ItemGroup>
 
 </Project>

--- a/test/UsecaseTests/ConfigurationHelper.cs
+++ b/test/UsecaseTests/ConfigurationHelper.cs
@@ -1,0 +1,23 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using Usecases;
+
+namespace UnitTests
+{
+    public class ConfigurationHelper
+    {
+
+        public static void SetDocumentConfigEnvironmentVariable()
+        {
+            var configObj = new DocumentConfig
+            {
+                Categories = new List<string> { "Benefits/Out-Going" },
+                Descriptions = new List<string> { "Benefits Blank Letter", "Change in Circs ICL" },
+                AutomaticApprovals = new List<string> { "Benefits Blank Letter" }
+            };
+
+            Environment.SetEnvironmentVariable("DOCUMENT_CONFIG", JsonConvert.SerializeObject(configObj));
+        }
+    }
+}

--- a/test/UsecaseTests/ConfigurationHelperTests.cs
+++ b/test/UsecaseTests/ConfigurationHelperTests.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using Usecases;
+
+namespace UnitTests
+{
+    public class ConfigurationHelperTests
+    {
+        [Test]
+        public void SetsDocumentConfigurationEnvironmentVariableWithCorrectValues()
+        {
+            var expected = new DocumentConfig
+            {
+                Categories = new List<string> { "Benefits/Out-Going" },
+                Descriptions = new List<string> { "Benefits Blank Letter", "Change in Circs ICL" },
+                AutomaticApprovals = new List<string> { "Benefits Blank Letter" }
+            };
+
+            ConfigurationHelper.SetDocumentConfigEnvironmentVariable();
+
+            var received = Environment.GetEnvironmentVariable("DOCUMENT_CONFIG");
+
+            Assert.AreEqual(JsonConvert.SerializeObject(expected), received);
+        }
+    }
+}

--- a/test/UsecaseTests/ParsingHelpersTests.cs
+++ b/test/UsecaseTests/ParsingHelpersTests.cs
@@ -1,13 +1,21 @@
-using System.Collections.Generic;
 using FluentAssertions;
+using Newtonsoft.Json;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 using Usecases;
-using Usecases.UntestedParsers;
 
 namespace UnitTests
 {
     public class ParsingHelpersTests
     {
+
+        [SetUp]
+        public void Setup()
+        {
+            ConfigurationHelper.SetDocumentConfigEnvironmentVariable();
+        }
+
         [Test]
         public void FormatHeaderReturnsFormattedTableIncludingTheAddress()
         {
@@ -83,6 +91,6 @@ namespace UnitTests
 
             var result = ParsingHelpers.FormatLetterHeader(addressLines, "");
             result.Should().Contain(expectedAddressString);
-        }
+        }       
     }
 }

--- a/test/UsecaseTests/ProcessEventsTests.cs
+++ b/test/UsecaseTests/ProcessEventsTests.cs
@@ -12,6 +12,7 @@ using Usecases.Enums;
 using Usecases.GatewayInterfaces;
 using UseCases.GatewayInterfaces;
 using Usecases.Interfaces;
+using Newtonsoft.Json;
 
 namespace UnitTests
 {
@@ -38,6 +39,8 @@ namespace UnitTests
             _localDbGateway = new Mock<ILocalDatabaseGateway>();
             _processEvents = new ProcessEvents(_mockGetHtmlDocument.Object, _mockPdfParser.Object, _sendToS3.Object,
                 _mockGetDocDetails.Object, _logger.Object, _localDbGateway.Object);
+
+            ConfigurationHelper.SetDocumentConfigEnvironmentVariable();
         }
 
         [Test]
@@ -239,5 +242,6 @@ namespace UnitTests
             var testRun = new AsyncTestDelegate(async () => await _processEvents.Execute(sqsEventMock));
             Assert.ThrowsAsync<Exception>(testRun);
         }
+               
     }
 }


### PR DESCRIPTION
1. Improve Change in Circs letter parser to keep the paging in line with the original template
2. Add support for controlling manual approvals per letter type using environment variable