### PR TITLE
Simple templates

### DIFF
--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -39,6 +39,8 @@ namespace UseCases
                     return new HBCTBInviteForDeceasedCustomersPa();
                 case "HB/CTB Invite For Deceased Cust Relative":
                     return new HBCTBInviteForDeceasedCustRelative();
+                case "HB Termination of claim for HB/CTB":
+                    return new HBTerminationOfClaimForHBCTB();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -21,6 +21,8 @@ namespace UseCases
                     return new ReviewICL();
                 case "Adverse Inference (BEN 999)":
                     return new AdverseInferenceBEN999();
+                case "Revision-decision upheld":
+                    return new RevisionDecisionUpheld();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -33,6 +33,8 @@ namespace UseCases
                     return new LateNotification();
                 case "Benefit Suspend Letter":
                     return new BenefitSuspendLetter();
+                case "Invite To Claim CTR - Claimed HB via DWP":
+                    return new InviteToClaimCTRClaimedHBviaDWP();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -23,6 +23,8 @@ namespace UseCases
                     return new AdverseInferenceBEN999();
                 case "Revision-decision upheld":
                     return new RevisionDecisionUpheld();
+                case "Backdate Accepted":
+                    return new BackdateAccepted();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -37,6 +37,8 @@ namespace UseCases
                     return new InviteToClaimCTRClaimedHBviaDWP();
                 case "HB/CTB Invite For Deceased Customer's Pa":
                     return new HBCTBInviteForDeceasedCustomersPa();
+                case "HB/CTB Invite For Deceased Cust Relative":
+                    return new HBCTBInviteForDeceasedCustRelative();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -35,6 +35,8 @@ namespace UseCases
                     return new BenefitSuspendLetter();
                 case "Invite To Claim CTR - Claimed HB via DWP":
                     return new InviteToClaimCTRClaimedHBviaDWP();
+                case "HB/CTB Invite For Deceased Customer's Pa":
+                    return new HBCTBInviteForDeceasedCustomersPa();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -25,6 +25,8 @@ namespace UseCases
                     return new RevisionDecisionUpheld();
                 case "Backdate Accepted":
                     return new BackdateAccepted();
+                case "Revision-decision revised":
+                    return new RevisionDecisionRevised();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -29,6 +29,8 @@ namespace UseCases
                     return new RevisionDecisionRevised();
                 case "Backdate Refused":
                     return new BackdateRefused();
+                case "Late Notification":
+                    return new LateNotification();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -31,6 +31,8 @@ namespace UseCases
                     return new BackdateRefused();
                 case "Late Notification":
                     return new LateNotification();
+                case "Benefit Suspend Letter":
+                    return new BenefitSuspendLetter();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -43,6 +43,8 @@ namespace UseCases
                     return new HBTerminationOfClaimForHBCTB();
                 case "Revision-further info requested":
                     return new RevisionFurtherInfoRequested();
+                case "UC HB/CTR cancelled":
+                    return new UCHBCTRCancelled();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -41,6 +41,8 @@ namespace UseCases
                     return new HBCTBInviteForDeceasedCustRelative();
                 case "HB Termination of claim for HB/CTB":
                     return new HBTerminationOfClaimForHBCTB();
+                case "Revision-further info requested":
+                    return new RevisionFurtherInfoRequested();
                 default:
                     return null;
             }

--- a/src/Usecases/ParserLookup.cs
+++ b/src/Usecases/ParserLookup.cs
@@ -27,6 +27,8 @@ namespace UseCases
                     return new BackdateAccepted();
                 case "Revision-decision revised":
                     return new RevisionDecisionRevised();
+                case "Backdate Refused":
+                    return new BackdateRefused();
                 default:
                     return null;
             }

--- a/src/Usecases/UntestedParsers/BackdateAccepted.cs
+++ b/src/Usecases/UntestedParsers/BackdateAccepted.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class BackdateAccepted : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/BackdateRefused.cs
+++ b/src/Usecases/UntestedParsers/BackdateRefused.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class BackdateRefused : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/BenefitSuspendLetter.cs
+++ b/src/Usecases/UntestedParsers/BenefitSuspendLetter.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class BenefitSuspendLetter : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/HBCTBInviteForDeceasedCustRelative.cs
+++ b/src/Usecases/UntestedParsers/HBCTBInviteForDeceasedCustRelative.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class HBCTBInviteForDeceasedCustRelative : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/HBCTBInviteForDeceasedCustomersPa.cs
+++ b/src/Usecases/UntestedParsers/HBCTBInviteForDeceasedCustomersPa.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class HBCTBInviteForDeceasedCustomersPa : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/HBTerminationOfClaimForHBCTB.cs
+++ b/src/Usecases/UntestedParsers/HBTerminationOfClaimForHBCTB.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class HBTerminationOfClaimForHBCTB : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/InviteToClaimCTRClaimedHBviaDWP.cs
+++ b/src/Usecases/UntestedParsers/InviteToClaimCTRClaimedHBviaDWP.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class InviteToClaimCTRClaimedHBviaDWP : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/LateNotification.cs
+++ b/src/Usecases/UntestedParsers/LateNotification.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class LateNotification : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/RevisionDecisionRevised.cs
+++ b/src/Usecases/UntestedParsers/RevisionDecisionRevised.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class RevisionDecisionRevised : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/RevisionDecisionUpheld.cs
+++ b/src/Usecases/UntestedParsers/RevisionDecisionUpheld.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class RevisionDecisionUpheld : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/RevisionFurtherInfoRequested.cs
+++ b/src/Usecases/UntestedParsers/RevisionFurtherInfoRequested.cs
@@ -1,0 +1,69 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class RevisionFurtherInfoRequested : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var rows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 8);
+            return $"<table> {rows.Aggregate("", (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[8]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[9]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}

--- a/src/Usecases/UntestedParsers/UCHBCTRCancelled.cs
+++ b/src/Usecases/UntestedParsers/UCHBCTRCancelled.cs
@@ -1,0 +1,79 @@
+﻿using HtmlAgilityPack;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Usecases.Domain;
+using Usecases.Interfaces;
+
+namespace Usecases.UntestedParsers
+{
+    class UCHBCTRCancelled : ILetterParser
+    {
+        public LetterTemplate Execute(string html)
+        {
+            var documentNode = GetDocumentNode(html);
+            var address = ParseAddressIntoLines(documentNode);
+
+            var rightSideOfHeader = ParseSenderAddress(documentNode) + ContactDetails(documentNode);
+
+            var mainBody = documentNode.SelectSingleNode("html/body");
+            mainBody.RemoveChild(mainBody.SelectSingleNode("table[1]"));
+
+            var templateSpecificCss = documentNode.SelectSingleNode("html/head/style").InnerText;
+            return new LetterTemplate
+            {
+                TemplateSpecificCss = templateSpecificCss,
+                AddressLines = address,
+                RightSideOfHeader = rightSideOfHeader,
+                MainBody = mainBody.OuterHtml,
+            };
+        }
+
+        private static string ParseSenderAddress(HtmlNode documentNode)
+        {
+            var table = documentNode.SelectNodes("html/body/table[1]/tr").ToList();
+            return table
+                .GetRange(1, 7)
+                .Aggregate("", (accString, node) =>
+                    accString + $"<p> {node.SelectNodes("td").Last().InnerHtml} </p>");
+        }
+
+        private static string ContactDetails(HtmlNode documentNode)
+        {
+            var firstRow = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(8, 1)[0];
+            var secondRow = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(9, 1)[0];
+
+            firstRow.RemoveChild(firstRow.SelectSingleNode("td[1]"));
+            secondRow.RemoveChild(secondRow.SelectSingleNode("td[1]"));
+
+            string startAcc = $"{firstRow.OuterHtml + secondRow.OuterHtml}";
+
+            var remainingRows = documentNode.SelectNodes("/html/body/table[1]/tr")
+                .ToList().GetRange(10, 6);
+            return $"<table> {remainingRows.Aggregate(startAcc, (accRows, row) => accRows + row.OuterHtml)} </table>";
+        }
+
+        private static List<string> ParseAddressIntoLines(HtmlNode documentNode)
+        {
+            var addressList = new List<string>();
+            var name = documentNode.SelectSingleNode("/html/body/table/tr[9]/td[1]");
+
+            addressList.Add(name.InnerText);
+
+            documentNode.SelectSingleNode("/html/body/table[1]/tr[10]/td[1]").ChildNodes.ToList()
+                .ForEach(line => addressList.Add(line.InnerText));
+
+            return addressList;
+        }
+
+        private static HtmlNode GetDocumentNode(string html)
+        {
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+            return doc.DocumentNode;
+        }
+    }
+}


### PR DESCRIPTION
# What:
- 12 HTML Parsers for Letters with Simple Template Layouts.
- Templates list from this PR:
﻿
Revision-decision upheld
Backdate Accepted
Revision-decision revised
Backdate Refused
Late Notification
Benefit Suspend Letter
Invite To Claim CTR - Claimed HB via DWP
HB/CTB Invite For Deceased Customer's Pa
HB/CTB Invite For Deceased Cust Relative
HB Termination of claim for HB/CTB
Revision-further info requested
UC HB/CTR cancelled


# Why:
- Agents used to print these letters in the office by hand. Now that they can't due to CV-19, this has to be done through gov notify service. Gov Notify requires different letter layout than Hackney uses - in particular the address information block has to be in a specific place (different than usually).
- Original templates are of RTF format, so after their conversion to HTML, the places of certain pieces of information (DOM-wise) is different than what we want to. So parser is also used to restructure that information.

# Notes:
- Due to the simple layout of these templates, only the addresses tables had to be adjusted.
- Most of these templates had similar layout for address tables, hence it was a quick job to go trough them.
- Each template was testing with randomly selected 5 actual letters to ensure that it's not just a single instance is being displayed fine. Only 5 due to time constraints (it's pretty time consuming). Everything was tested using a local console application, so the layout might slightly differ when Parsed on AWS Lambda, however it was made sure that the layout is consistent between different templates generated within local machine.
- Each template was also checked by looking into RTF source templates to make sure they don't have hidden surprises of an optional table appearing from time to time (as it's the option in the application that generates these templates). All of them were confirmed to have either no options or very minor ones of a bit more text added on top (which is irrelevant layout-wise).
- The code duplication is pretty horrendous in this case, however it had to be this way as per team's agreement. The idea was that if we need to change one template later on for some layout changes, we won't affect the rest (as there is a trend for similar templates to have minor differences anyway).