### PR TITLE
Change AWS Lambda function timeout to max value

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -64,7 +64,7 @@ functions:
     name: ${self:service}-${self:provider.stage}-send-to-notify
     handler: Lambda::AwsDotnetCsharp.Handlers::QueryDocumentsAndSendToNotify
     role: arn:aws:iam::775052747630:role/LBH_Lambda_Execution
-    timeout: 90
+    timeout: 900
     events:
       - schedule: cron(30 15 ? * MON-FRI *) # every weekday at 3:30pm UTC
 


### PR DESCRIPTION
# What:
- A change to the notify print lambda function timeout value.

# Why:
- Due to circumstances of a lot letters accumulating over the weekend (when the lambda doesn't run to process them), lambda has to deal with all of them at once during a working day when it starts its work.  This makes the service timeout.

# Notes:
- Previous timeout was gradually being increased up until 90 seconds. However recently the run duration exceeded that as well.
It was decided to increase it to the maximum duration instead so we wouldn't have to do more dummy deployments.

![image](https://user-images.githubusercontent.com/43747286/85522730-f16c9580-b5fd-11ea-894c-fe3fd0fc024c.png)
